### PR TITLE
Bump Android examples to 1.0.1

### DIFF
--- a/documentation/Android/image-outline.md
+++ b/documentation/Android/image-outline.md
@@ -8,7 +8,7 @@ It is possible to get a white outline, or a colored one.
 1. To use the library in your project add the following line in your module gradle build file:
 
 ```gradle
-implementation 'com.omhu:image-outline:1.0.0'
+implementation 'com.omhu:image-outline:1.0.1'
 ```
 
 2. Since the library is hosted in a private Maven repository you need to include the repository in your top-level gradle build file:

--- a/documentation/Android/image-suitability-prediction.md
+++ b/documentation/Android/image-suitability-prediction.md
@@ -16,7 +16,7 @@ Where "no evaluation possible" means that the quality of the photo is very bad (
 1. To use the library in your project add the following line in your module gradle build file:
 
 ```gradle
-implementation 'com.omhu:suitability-prediction:1.0.0'
+implementation 'com.omhu:suitability-prediction:1.0.1'
 ```
 
 2. Since the library is hosted in a private Maven repository you need to include the repository in your top level gradle build file:

--- a/examples/Android/ImageOutline/app/build.gradle
+++ b/examples/Android/ImageOutline/app/build.gradle
@@ -37,5 +37,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
 
-    implementation 'com.omhu:image-outline:1.0.0'
+    implementation 'com.omhu:image-outline:1.0.1'
 }

--- a/examples/Android/SuitabilityPredictionClient/app/build.gradle
+++ b/examples/Android/SuitabilityPredictionClient/app/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
 
-    implementation 'com.omhu:suitability-prediction:1.0.0'
+    implementation 'com.omhu:suitability-prediction:1.0.1'
 }


### PR DESCRIPTION
This PR bumps the examples and readmes to use the 1.0.1 versions of the Android libs.